### PR TITLE
Increase Timeout

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,7 +68,7 @@ nodeWithTimeout('docker') {
 
 void nodeWithTimeout(String label, def body) {
     node(label) {
-        timeout(time: 40, unit: 'MINUTES') {
+        timeout(time: 60, unit: 'MINUTES') {
             body.call()
         }
     }


### PR DESCRIPTION
Adding additional images for openj9 makes the build take longer. Allow up to 60 minutes.